### PR TITLE
Custom certificate

### DIFF
--- a/helm/designate-certmanager-webhook/templates/deployment.yaml
+++ b/helm/designate-certmanager-webhook/templates/deployment.yaml
@@ -85,6 +85,9 @@ spec:
             - name: certs
               mountPath: /tls
               readOnly: true
+            {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12}}
+            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           securityContext:
@@ -97,6 +100,9 @@ spec:
           secret:
             optional: true
             secretName: {{ include "designate-certmanager-webhook.servingCertificate" . }}
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8}}
+        {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/helm/designate-certmanager-webhook/templates/secret.yaml
+++ b/helm/designate-certmanager-webhook/templates/secret.yaml
@@ -40,6 +40,9 @@ data:
   {{- if .Values.openstack.domain_name }}
   OS_DOMAIN_NAME: {{ .Values.openstack.domain_name | b64enc | quote }}
   {{- end }}
+  {{- if .Values.openstack.ca_cert }}
+  OS_CACERT: {{ .Values.openstack.ca_cert | b64enc | quote }}
+  {{- end }}
   {{- if .Values.openstack.auth_type }}
   OS_AUTH_TYPE: {{ .Values.openstack.auth_type | b64enc | quote }}
   {{- end }}

--- a/helm/designate-certmanager-webhook/values.yaml
+++ b/helm/designate-certmanager-webhook/values.yaml
@@ -37,6 +37,7 @@ openstack:
   region_name: ""
   auth_url: ""
   domain_name: ""
+  ca_cert: ""
 
 nameOverride: ""
 fullnameOverride: ""

--- a/helm/designate-certmanager-webhook/values.yaml
+++ b/helm/designate-certmanager-webhook/values.yaml
@@ -39,6 +39,8 @@ openstack:
   domain_name: ""
   ca_cert: ""
 
+extraVolumes: []
+extraVolumeMounts: []
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
Adds options for custom CA, which is not being merged upstream: https://github.com/syseleven/designate-certmanager-webhook/pull/104