### PR TITLE
Add helm labels and annotations to `APIService`

### DIFF
--- a/helm/designate-certmanager-webhook/templates/apiservice.yaml
+++ b/helm/designate-certmanager-webhook/templates/apiservice.yaml
@@ -18,7 +18,10 @@ data:
         chart: {{ include "designate-certmanager-webhook.chart" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
+        app.kubernetes.io/managed-by: "Helm"
       annotations:
+        meta.helm.sh/release-name: {{ .Release.Name }}
+        meta.helm.sh/release-namespace: {{ .Release.Namespace }}
         cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "designate-certmanager-webhook.servingCertificate" . }}"
     spec:
       group: acme.syseleven.de

--- a/helm/designate-certmanager-webhook/templates/apiservice.yaml
+++ b/helm/designate-certmanager-webhook/templates/apiservice.yaml
@@ -18,7 +18,7 @@ data:
         chart: {{ include "designate-certmanager-webhook.chart" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
-        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
       annotations:
         meta.helm.sh/release-name: {{ .Release.Name }}
         meta.helm.sh/release-namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
This eases the rollout of https://github.com/stackitcloud/designate-certmanager-webhook/pull/28

After users install a version including this change, they can update to a version wich applies the APIService directly without any manual actions required.